### PR TITLE
PHPDocの訂正？？

### DIFF
--- a/ApplicationInsights/Telemetry_Client.php
+++ b/ApplicationInsights/Telemetry_Client.php
@@ -130,7 +130,7 @@ class Telemetry_Client
     /**
      * Sends an Message_Data to the Application Insights service.
      * @param string $message The trace message.
-     * @param string $severityLevel The severity level of the message. Found: \ApplicationInsights\Channel\Contracts\Message_Severity_Level::Value
+     * @param int|null $severityLevel The severity level of the message. Found: \ApplicationInsights\Channel\Contracts\Message_Severity_Level::Value
      * @param array $properties An array of name to value pairs. Use the name as the index and any string as the value.
      */
     public function trackMessage($message, $severityLevel = NULL, $properties = NULL)


### PR DESCRIPTION
多分intが正しいのかなぁと思いPR作りました！

```php
<?php
namespace ApplicationInsights\Channel\Contracts;
/**
*  
* THIS FILE IS AUTO-GENERATED.  
* Please do not edit manually. 
*  
* Use script at <root>/Schema/generateSchema.ps1 
*  
*/
/**
* Enum Severity_Level. 
*/
abstract class Severity_Level
{
    const Verbose = 0;
    const Information = 1;
    const Warning = 2;
    const Error = 3;
    const Critical = 4;
}

```